### PR TITLE
Fix Windows-build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ upgradeid = (
 
 build_exe_options = {
     "include_msvcr": True,
-    "include_files": (r"./sun-valley.tcl", r"./utils.py", r"./theme", r"./assets"),
-    "includes": ["tkinter", "platform", "threading", "BlurWindow", "darkdetect"],
+    "include_files": (r"./utils.py", r"./assets"),
+    "includes": ["tkinter", "platform", "threading", "BlurWindow", "darkdetect", "sv_ttk"],
 }
 
 bdist_rpm_options = {"icon": icon}


### PR DESCRIPTION
Remove `sun-valley.tcl` and `theme/*` from setup.py since it now uses sv-ttk instead.